### PR TITLE
impls/uxx: change loop to while loop

### DIFF
--- a/src/impls/uxx.rs
+++ b/src/impls/uxx.rs
@@ -5,15 +5,15 @@ use crate::{uDebug, uDisplay, uWrite, Formatter};
 macro_rules! uxx {
     ($n:expr, $buf:expr) => {{
         let mut n = $n;
-        let mut i = $buf.len() - 1;
+        let mut i = $buf.len();
         while i > 0 {
+            i -= 1;
+
             unsafe { *$buf.get_unchecked_mut(i) = (n % 10) as u8 + b'0' };
             n = n / 10;
 
             if n == 0 {
                 break;
-            } else {
-                i -= 1;
             }
         }
 

--- a/src/impls/uxx.rs
+++ b/src/impls/uxx.rs
@@ -6,18 +6,14 @@ macro_rules! uxx {
     ($n:expr, $buf:expr) => {{
         let mut n = $n;
         let mut i = $buf.len() - 1;
-        loop {
+        while i > 0 {
             unsafe { *$buf.get_unchecked_mut(i) = (n % 10) as u8 + b'0' };
             n = n / 10;
 
             if n == 0 {
                 break;
             } else {
-                if (i > 0) {
-                    i -= 1;
-                } else {
-                    break;
-                }
+                i -= 1;
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@
 //! - `uwrite!` / `uwriteln!`
 //!
 //! ```
+//! # use aya_ufmt as ufmt;
 //! use ufmt::{derive::uDebug, uwrite};
 //!
 //! #[derive(uDebug)]
@@ -60,6 +61,7 @@
 //! ```
 //! use core::convert::Infallible;
 //!
+//! # use aya_ufmt as ufmt;
 //! use ufmt_write::uWrite;
 //!
 //! struct MyWriter;
@@ -158,6 +160,7 @@
 //! ```
 //! use core::{convert::Infallible, fmt, ptr};
 //!
+//! # use aya_ufmt as ufmt;
 //! use ufmt::uWrite;
 //!
 //! struct W;

--- a/tests/vs-std-write.rs
+++ b/tests/vs-std-write.rs
@@ -1,13 +1,14 @@
 use core::convert::Infallible;
 use std::collections::{BTreeMap, BTreeSet};
 
-use ufmt::{derive::uDebug, uDebug, uWrite, uwrite, uwriteln, Formatter};
+use aya_ufmt as ufmt;
+use aya_ufmt::{derive::uDebug, uDebug, uWrite, uwrite, uwriteln, Formatter};
 
 macro_rules! uformat {
     ($($tt:tt)*) => {{
         let mut s = String::new();
         #[allow(unreachable_code)]
-        match ufmt::uwrite!(&mut s, $($tt)*) {
+        match aya_ufmt::uwrite!(&mut s, $($tt)*) {
             Ok(_) => Ok(s),
             Err(e) => Err(e),
         }
@@ -72,7 +73,6 @@ fn uxx() {
     cmp!("{}", u16::max_value());
     cmp!("{}", u32::max_value());
     cmp!("{}", u64::max_value());
-    cmp!("{}", u128::max_value());
     cmp!("{}", usize::max_value());
 }
 
@@ -92,8 +92,6 @@ fn ixx() {
     cmp!("{}", i32::max_value());
     cmp!("{}", i64::min_value());
     cmp!("{}", i64::max_value());
-    cmp!("{}", i128::min_value());
-    cmp!("{}", i128::max_value());
     cmp!("{}", isize::min_value());
     cmp!("{}", isize::max_value());
 }


### PR DESCRIPTION
The verifier was unable to properly reason about this loop, causing an error when logging
unsigned types. This patch fixes the issue. Fixes https://github.com/aya-rs/aya-log/issues/2.